### PR TITLE
Fix release build for preference search

### DIFF
--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "com.squareup.moshi:moshi:1.2.0"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "org.apache.james:apache-mime4j-core:${versions.mime4j}"
+    implementation 'com.github.ByteHamster:SearchPreference:v1.1.3'
 
     testImplementation project(':mail:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"

--- a/app/core/src/main/res/values/attrs.xml
+++ b/app/core/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="K9Styles">
+        <attr name="iconActionSearch" format="reference" />
+    </declare-styleable>
+
+</resources>

--- a/app/core/src/main/res/values/strings.xml
+++ b/app/core/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+    <string name="search_action">Search</string>
+</resources>

--- a/app/k9mail/proguard-rules.pro
+++ b/app/k9mail/proguard-rules.pro
@@ -23,3 +23,4 @@
 -dontnote com.fsck.k9.view.**
 
 -keep public class org.openintents.openpgp.**
+-keep public class com.bytehamster.lib.preferencesearch.** { *; }


### PR DESCRIPTION
I like the preference search very much. It did, however, not work in release builds.

This  should fix missing resources for `assembleRelease` build and the proguard obfuscation resulting in:

```
07-16 15:07:48.198 16499 16499 W SupportMenuInflater: Cannot instantiate class: com.bytehamster.lib.preferencesearch.SearchPreferenceActionView
07-16 15:07:48.198 16499 16499 W SupportMenuInflater: java.lang.NoSuchMethodException: <init> [class android.content.Context]
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at java.lang.Class.getConstructor0(Class.java:2320)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at java.lang.Class.getConstructor(Class.java:1725)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.support.v7.view.SupportMenuInflater$MenuState.newInstance(SupportMenuInflater.java:548)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.support.v7.view.SupportMenuInflater$MenuState.setItem(SupportMenuInflater.java:495)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.support.v7.view.SupportMenuInflater$MenuState.addItem(SupportMenuInflater.java:529)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.support.v7.view.SupportMenuInflater.parseMenu(SupportMenuInflater.java:205)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.support.v7.view.SupportMenuInflater.inflate(SupportMenuInflater.java:127)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at com.fsck.k9.ui.settings.general.GeneralSettingsActivity.onCreateOptionsMenu(GeneralSettingsActivity.kt:61)
07-16 15:07:48.198 16499 16499 W SupportMenuInflater:   at android.app.Activity.onCreatePanelMenu(Activity.java:3388)

```
